### PR TITLE
Lowercase strings in `email()`

### DIFF
--- a/src/dj.erl
+++ b/src/dj.erl
@@ -347,7 +347,7 @@ existing_atom(Allowed) ->
 %% '''
 -spec email() -> decoder(binary()).
 email() ->
-  chain( binary()
+  chain( map(fun string:lowercase/1, binary())
        , fun (V) ->
              case re:run( V
                         , <<"^[^@\s]+@([^.@\s]{2,}\.){1,}[a-z]{2,}$">>

--- a/test/dj_test.erl
+++ b/test/dj_test.erl
@@ -92,7 +92,8 @@ decode_one_of_as_default_test() ->
   ok.
 
 decode_email_test() ->
-  {ok, _} = dj:decode(<<"\"ilias@truqu.com\"">>, dj:email()),
+  {ok, <<"ilias@truqu.com">>} = dj:decode(<<"\"ilias@truqu.com\"">>, dj:email()),
+  {ok, <<"ilias@truqu.com">>} = dj:decode(<<"\"ILIAS@TRUQU.COM\"">>, dj:email()),
   {error, _} = dj:decode(<<"\"foo@bar\"">>, dj:email()),
   ok.
 


### PR DESCRIPTION
This normalizes strings returned by `email()`:

```erlang
  {ok, <<"ilias@truqu.com">>} = dj:decode(<<"\"ilias@truqu.com\"">>, dj:email()),
  {ok, <<"ilias@truqu.com">>} = dj:decode(<<"\"ILIAS@TRUQU.COM\"">>, dj:email()),
```